### PR TITLE
API: use lowercase Python module names.

### DIFF
--- a/docs/mappdf.rst
+++ b/docs/mappdf.rst
@@ -20,10 +20,10 @@ mappdf\.glbl module
     :undoc-members:
     :show-inheritance:
 
-mappdf\.mapPDF module
+mappdf\.mappdf module
 ---------------------
 
-.. automodule:: mappdf.mapPDF
+.. automodule:: mappdf.mappdf
     :members:
     :undoc-members:
     :show-inheritance:

--- a/rever.xsh
+++ b/rever.xsh
@@ -7,7 +7,7 @@ $ACTIVITIES = [
               'ghrelease'  # Creates a Github release entry for the new tag
                ]
 $VERSION_BUMP_PATTERNS = [  # These note where/how to find the version numbers
-                         ('mapPDF/__init__.py', '__version__\s*=.*', "__version__ = '$VERSION'"),
+                         ('mappdf/__init__.py', '__version__\s*=.*', "__version__ = '$VERSION'"),
                          ('setup.py', 'version\s*=.*,', "version='$VERSION',")
                          ]
 $CHANGELOG_FILENAME = 'CHANGELOG.rst'  # Filename for the changelog


### PR DESCRIPTION
Rename `mappdf.mapPDF` --> `mappdf.mappdf`.

https://www.python.org/dev/peps/pep-0008/#package-and-module-names